### PR TITLE
Add Grafana dashboard provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ This setup runs two Kafka brokers (`kafka1`, `kafka2`), both acting as controlle
     *   Targets: "Status" -> "Targets". Scrapes `kafka1:9999`, `kafka2:9998`, and `kafka-exporter:9308`.
 *   **Kafka Exporter:** Exposes metrics on `http://localhost:9308` for Prometheus.
 *   **Grafana:** `http://localhost:3000` (admin/admin)
-    *   Add Prometheus data source: URL `http://prometheus:9090`.
-    *   Import Kafka dashboards (e.g., from Grafana Labs, search for Bitnami Kafka or JMX ones).
+    *   Comes preconfigured with a Prometheus data source pointing to `http://prometheus:9090`.
+    *   A sample **Kafka Overview** dashboard is automatically imported and available after startup.
 
 ## Data Persistence
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,8 +118,10 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD: admin
       GF_USERS_ALLOW_SIGN_UP: "false"
-    # volumes:
-    #   - grafana-storage:/var/lib/grafana
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
     networks:
       - kafkanet
 

--- a/grafana/dashboards/kafka-overview.json
+++ b/grafana/dashboards/kafka-overview.json
@@ -1,0 +1,76 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1625779238398,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "legend": {"showLegend": true}
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(kafka_server_brokertopicmetrics_messages_in_total[1m]))",
+          "legendFormat": "Messages In",
+          "refId": "A"
+        }
+      ],
+      "title": "Messages In Per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {
+        "legend": {"showLegend": true}
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(kafka_server_brokertopicmetrics_bytes_in_total[1m]))",
+          "legendFormat": "Bytes In",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(kafka_server_brokertopicmetrics_bytes_out_total[1m]))",
+          "legendFormat": "Bytes Out",
+          "refId": "B"
+        }
+      ],
+      "title": "Bytes In/Out Per Second",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": ["kafka"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kafka Overview",
+  "uid": "kafka-overview",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/default.yml
+++ b/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true


### PR DESCRIPTION
## Summary
- add Grafana provisioning directories
- auto-load Prometheus datasource and Kafka dashboard
- document the preconfigured dashboard in README

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439cc2581c83299a8254a28d16eaad