### PR TITLE
Add Kafka UI and persist Grafana data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-This project provides an automated and scalable Apache Kafka cluster management setup using Docker Compose. It leverages KRaft mode for a Zookeeper-less architecture and uses `bitnami/kafka` Docker images, tailored for local containerized environments and testing. Monitoring is provided via Prometheus, Grafana, and a Kafka exporter.
+This project provides an automated and scalable Apache Kafka cluster management setup using Docker Compose. It leverages KRaft mode for a Zookeeper-less architecture and uses `bitnami/kafka` Docker images, tailored for local containerized environments and testing. Monitoring and management are provided via Prometheus, Grafana, a Kafka exporter, and Kafka UI.
 
 # Kafka Docker Compose Setup (KRaft Mode with Bitnami Images)
 
-This project provides a Docker Compose setup for running a Zookeeper-less Apache Kafka cluster locally using KRaft mode with `bitnami/kafka` images. It includes monitoring via Prometheus, Grafana, and a Kafka exporter.
+This project provides a Docker Compose setup for running a Zookeeper-less Apache Kafka cluster locally using KRaft mode with `bitnami/kafka` images. It includes monitoring via Prometheus, Grafana, a Kafka exporter, and Kafka UI.
 
 ## Prerequisites
 
@@ -43,14 +43,14 @@ Key KRaft configuration parameters (found in `docker-compose.yml` under each Kaf
     ```bash
     docker-compose up -d
     ```
-    This command will start the Kafka brokers, the Kafka exporter, Prometheus, and Grafana services in detached mode. Zookeeper is not used.
+    This command will start the Kafka brokers along with the Kafka exporter, Prometheus, Grafana, and Kafka UI services in detached mode. Zookeeper is not used.
 
 3.  **Verify the services are running:**
     You can check the status of the containers using:
     ```bash
     docker-compose ps
     ```
-    You should see `kafka1`, `kafka2`, `kafka-exporter`, `prometheus`, and `grafana` containers running.
+    You should see `kafka1`, `kafka2`, `kafka-exporter`, `prometheus`, `grafana`, and `kafka-ui` containers running.
 
 ## Accessing Kafka
 
@@ -138,12 +138,14 @@ This setup runs two Kafka brokers (`kafka1`, `kafka2`), both acting as controlle
 *   **Grafana:** `http://localhost:3000` (admin/admin)
     *   Add Prometheus data source: URL `http://prometheus:9090`.
     *   Import Kafka dashboards (e.g., from Grafana Labs, search for Bitnami Kafka or JMX ones).
+*   **Kafka UI:** `http://localhost:8080`
 
 ## Data Persistence
 
-Kafka message data is persisted in Docker named volumes:
+Kafka message data and Grafana dashboards are persisted in Docker named volumes:
 *   `kafka1_data` for `kafka1` (mounted at `/bitnami/kafka`)
 *   `kafka2_data` for `kafka2` (mounted at `/bitnami/kafka`)
+*   `grafana-storage` for Grafana (mounted at `/var/lib/grafana`)
 These volumes are not deleted when you run `docker-compose down` unless you use the `-v` flag.
 
 ## Networking

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,15 +118,29 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD: admin
       GF_USERS_ALLOW_SIGN_UP: "false"
-    # volumes:
-    #   - grafana-storage:/var/lib/grafana
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    networks:
+      - kafkanet
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "8080:8080"
+    depends_on:
+      - kafka1
+      - kafka2
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: "kafka1:9092,kafka2:19092"
     networks:
       - kafkanet
 
 volumes:
   kafka1_data: {}
   kafka2_data: {}
-  # grafana-storage: {}
+  grafana-storage: {}
 
 networks: # Define a custom network
   kafkanet:


### PR DESCRIPTION
## Summary
- persist Grafana data in a volume
- add `kafka-ui` service for cluster management
- document new service and volume in README

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a203527c83298ab30bba1ceed81e