### PR TITLE
Add monitoring config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,14 @@ version: '3.8'
 
 services:
 
+  jmx-exporter-init:
+    image: curlimages/curl:latest
+    command: >
+      sh -c 'curl -L -o /opt/jmx-exporter/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.20.0/jmx_prometheus_javaagent-0.20.0.jar'
+    volumes:
+      - ./jmx-exporter:/opt/jmx-exporter
+    restart: "no"
+
   kafka-1:
     image: apache/kafka:4.0.0
     container_name: kafka-1
@@ -27,6 +35,8 @@ services:
     volumes:
       - kafka-1-data:/var/lib/kafka/data
       - ./jmx-exporter:/opt/jmx-exporter
+    depends_on:
+      - jmx-exporter-init
 
   kafka-2:
     image: apache/kafka:4.0.0
@@ -53,6 +63,8 @@ services:
     volumes:
       - kafka-2-data:/var/lib/kafka/data
       - ./jmx-exporter:/opt/jmx-exporter
+    depends_on:
+      - jmx-exporter-init
 
   kafka-3:
     image: apache/kafka:4.0.0
@@ -79,6 +91,8 @@ services:
     volumes:
       - kafka-3-data:/var/lib/kafka/data
       - ./jmx-exporter:/opt/jmx-exporter
+    depends_on:
+      - jmx-exporter-init
 
   prometheus:
     image: prom/prometheus:latest

--- a/jmx-exporter/kafka.yml
+++ b/jmx-exporter/kafka.yml
@@ -1,0 +1,15 @@
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+
+rules:
+  - pattern: 'kafka.server<type=(.+), name=(.+)PerSec, topic=(.+)><>OneMinuteRate'
+    name: kafka_server_$1_$2_total
+    labels:
+      topic: "$3"
+    type: COUNTER
+  - pattern: 'kafka.server<type=(.+), name=(.+)><>Value'
+    name: kafka_server_$1_$2
+    type: GAUGE
+  - pattern: 'kafka.server<type=(.+), name=(.+)><>Count'
+    name: kafka_server_$1_$2_total
+    type: COUNTER

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'kafka'
+    static_configs:
+      - targets: ['kafka-1:7071', 'kafka-2:7072', 'kafka-3:7073']
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']


### PR DESCRIPTION
## Summary
- set up Prometheus scrape targets
- add a basic Kafka JMX Exporter configuration

## Testing
- `docker-compose config` *(fails: command not found)*
- `python3` import test for yaml *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845095dfcc88329bbafa576fcf52f95